### PR TITLE
多言語対応

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/resource/l10n
+tempkate-arb-file: app_en.arb
+output-localization-file: text_l10n.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/text_l10n.dart';
+import 'package:repository_get_app/resource/l10n/l10n_template.dart';
 import 'package:repository_get_app/resource/theme/color_theme.dart';
 import 'package:repository_get_app/resource/theme/text_theme.dart';
 
@@ -14,6 +16,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       theme: ThemeData(
         useMaterial3: true, //
         colorScheme: ColorTheme.lightScheme(), //
@@ -24,7 +28,10 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorTheme.darkScheme(),
         textTheme: TextScheme.textTheme(),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: MyHomePage(
+        title: AppLocalizations.of(context)?.titleHomeScreen ?? //
+            I10n().titleHome,
+      ),
     );
   }
 }
@@ -95,8 +102,9 @@ class _MyHomePageState extends State<MyHomePage> {
           // horizontal).
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
+            Text(
+              AppLocalizations.of(context)?.messagePushButtonManyTimes ??
+                  I10n().messagePushButtonManyTimes,
             ),
             Text(
               '$_counter',

--- a/lib/resource/l10n/app_en.arb
+++ b/lib/resource/l10n/app_en.arb
@@ -1,0 +1,5 @@
+{
+    "@@locale":"en",
+    "titleHomeScreen":"Flutter Demo Home Page",
+    "messagePushButtonManyTimes":"You have pushed the button this many times:"
+}

--- a/lib/resource/l10n/app_ja.arb
+++ b/lib/resource/l10n/app_ja.arb
@@ -1,0 +1,5 @@
+{
+    "@@locale":"ja",
+    "titleHomeScreen":"Flutter Demo ホーム画面",
+    "messagePushButtonManyTimes":"あなたは何度もボタンを押すことができます："
+}

--- a/lib/resource/l10n/app_ko.arb
+++ b/lib/resource/l10n/app_ko.arb
@@ -1,0 +1,5 @@
+{
+    "@@locale":"ko",
+    "titleHomeScreen":"Flutter 데모 홈 화면",
+    "messagePushButtonManyTimes":"버튼을 여러 번 누를 수 있습니다:"
+}

--- a/lib/resource/l10n/app_zh.arb
+++ b/lib/resource/l10n/app_zh.arb
@@ -1,0 +1,5 @@
+{
+    "@@locale":"zh",
+    "titleHomeScreen":"Flutter 演示主屏幕",
+    "messagePushButtonManyTimes":"该按钮可多次按下："
+}

--- a/lib/resource/l10n/l10n_template.dart
+++ b/lib/resource/l10n/l10n_template.dart
@@ -1,0 +1,9 @@
+class I10n {
+  factory I10n() => _instance ??= I10n._();
+  I10n._();
+  static I10n? _instance;
+
+  String get titleHome => 'Flutter Demo Home Page';
+  String get messagePushButtonManyTimes =>
+      'You have pushed the button this many times:';
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,6 +238,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -283,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,9 @@ dependencies:
   envied: ^0.5.4+1
   flutter:
     sdk: flutter
+  flutter_localizations: # 多言語ライブラリの本体
+    sdk: flutter  
+  intl: ^0.18.1
   pedantic_mono: ^1.24.0+1
 
 dev_dependencies:
@@ -22,3 +25,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  generate: true


### PR DESCRIPTION
issue
[多言語対応](https://github.com/Toma-0/repository_get_app/issues/4)

行ったこと
- 対応言語の決定
- 多言語対応できるようにMaterialAppを修正
- 文言をl10nに移動
- l10nに移動した文言をUI反映
- リント対応

