### PR TITLE
検索画面のriverpod周りの修正

### DIFF
--- a/lib/view/home/home_app_bar.dart
+++ b/lib/view/home/home_app_bar.dart
@@ -29,22 +29,18 @@ class SearchFieldAppBar extends ConsumerWidget {
               AppLocalizations.of(context)?.labelSearch ?? I10n().labelSearch,
         ),
         onChanged: (text) {
-          ref.watch(homeScreenNotifierProvider.notifier).changeSerchWord(text);
-          ref.watch(homeScreenNotifierProvider.notifier).initStateSearchList();
+          ref.read(homeScreenNotifierProvider.notifier).changeSerchWord(text);
+          ref.read(homeScreenNotifierProvider.notifier).initStateSearchList();
         },
       ),
       actions: [
         IconButton(
           icon: const Icon(Icons.clear),
           onPressed: () {
-            ref.watch(homeScreenNotifierProvider.notifier).changeSerchWord('');
-            ref
-                .watch(homeScreenNotifierProvider.notifier)
-                .initStateSearchList();
+            ref.read(homeScreenNotifierProvider.notifier).changeSerchWord('');
+            ref.read(homeScreenNotifierProvider.notifier).initStateSearchList();
 
-            ref
-                .watch(homeScreenNotifierProvider.notifier)
-                .changeSearchRelated();
+            ref.read(homeScreenNotifierProvider.notifier).changeSearchRelated();
           },
         ),
       ],
@@ -66,7 +62,7 @@ class ShowTitleAppBar extends ConsumerWidget {
         IconButton(
           icon: const Icon(Icons.search),
           onPressed: () => ref
-              .watch(homeScreenNotifierProvider.notifier)
+              .read(homeScreenNotifierProvider.notifier)
               .changeSearchRelated(),
         ),
       ],

--- a/lib/view/home/home_body.dart
+++ b/lib/view/home/home_body.dart
@@ -7,6 +7,16 @@ class HomeBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final searchWord = ref.watch(
+      homeScreenNotifierProvider.select(
+        (value) => value.serchWords,
+      ),
+    );
+    final itemCount = ref.watch(
+      homeScreenNotifierProvider.select(
+        (value) => value.itemCount,
+      ),
+    );
     return RefreshIndicator(
       child: Padding(
         padding: EdgeInsets.symmetric(
@@ -15,15 +25,16 @@ class HomeBody extends ConsumerWidget {
         child: ref
             .watch(
               FetchRepositoryListProvider(
-                ref.watch(homeScreenNotifierProvider).serchWords,
-                ref.watch(homeScreenNotifierProvider).itemCount,
+                searchWord,
+                itemCount,
                 '',
               ),
             )
             .when(
               data: (data) {
                 if (data.repositoryListState.isEmpty) {
-                  if (ref.watch(homeScreenNotifierProvider).serchWords == '') {
+                  //まだ検索されていないとき
+                  if (searchWord == '') {
                     return ListView(
                       dragStartBehavior: DragStartBehavior.down,
                       children: [
@@ -39,6 +50,7 @@ class HomeBody extends ConsumerWidget {
                       ],
                     );
                   }
+                  //検索したものの該当するリポジトリがなかった時
                   return ListView(
                     dragStartBehavior: DragStartBehavior.down,
                     children: [
@@ -109,8 +121,8 @@ class HomeBody extends ConsumerWidget {
       ),
       onRefresh: () => ref.refresh(
         FetchRepositoryListProvider(
-          ref.watch(homeScreenNotifierProvider).serchWords,
-          ref.watch(homeScreenNotifierProvider).itemCount,
+          searchWord,
+          itemCount,
           '',
         ).future,
       ),

--- a/lib/view/home/home_body.dart
+++ b/lib/view/home/home_body.dart
@@ -107,8 +107,13 @@ class HomeBody extends ConsumerWidget {
               ),
             ),
       ),
-      onRefresh: () =>
-          ref.refresh(FetchRepositoryListProvider('test', 20, '').future),
+      onRefresh: () => ref.refresh(
+        FetchRepositoryListProvider(
+          ref.watch(homeScreenNotifierProvider).serchWords,
+          ref.watch(homeScreenNotifierProvider).itemCount,
+          '',
+        ).future,
+      ),
     );
   }
 }


### PR DESCRIPTION
行ったこと
- refresh条件が正しくなかったため修正
ref.refresh(FetchRepositoryListProvider('test', 20, '').future),
→ref.refresh(
        FetchRepositoryListProvider(
          searchWord,
          itemCount,
          '',
        ).future,
      ),

- notifierをref.watchしている個所があったため修正
ref.watch(homeScreenNotifierProvider.notifier).changeSerchWord(text);
→ref.read(homeScreenNotifierProvider.notifier).changeSerchWord('');

- 変数をまとめる。